### PR TITLE
Convert tests to MJS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -22,6 +22,7 @@ Dockerfile      text eol=lf
 *.scss          text eol=lf
 *.js            text eol=lf
 *.jsx           text eol=lf
+*.mjs           text eol=lf
 *.ts            text eol=lf
 *.tsx           text eol=lf
 *.map           text eol=lf

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "devDependencies": {
     "form-data": "4.0.0",
     "mocha": "9.1.2",
-    "node-fetch": "2.6.1"
+    "node-fetch": "3.0.0"
   },
   "scripts": {
     "test": "mocha test/mocha/*.test.js --timeout 5000"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
     "node-fetch": "3.0.0"
   },
   "scripts": {
-    "test": "mocha test/mocha/*.test.js --timeout 5000"
+    "test": "mocha test/mocha/*.test.mjs --timeout 5000"
   }
 }

--- a/test/mocha/fixtures.test.mjs
+++ b/test/mocha/fixtures.test.mjs
@@ -1,9 +1,8 @@
 /* eslint-env node, mocha */
-/* eslint-disable prefer-arrow-callback */
-"use strict";
-const {strictEqual} = require("assert");
-const fetch = require("node-fetch");
-const FormData = require("form-data");
+import {strictEqual} from "assert";
+import fetch from "node-fetch";
+import FormData from "form-data";
+
 
 it("GET: URLSearchParams", async function () {
 	const data = new URLSearchParams({param1: "AAAAAA"});


### PR DESCRIPTION
Upgraded `node-fetch` and switched to MJS `import` statements because `node-fetch` is now an ESM-only package.